### PR TITLE
Implement TTL-based Product Cache

### DIFF
--- a/src/app/core/config.py
+++ b/src/app/core/config.py
@@ -26,6 +26,9 @@ class Settings(BaseSettings):
     rate_limit_requests: int = 100
     rate_limit_window_seconds: int = 60
 
+    # Caching
+    cache_ttl_seconds: int = 3600
+
     model_config = SettingsConfigDict(
         env_file=".env",
         env_file_encoding="utf-8",

--- a/src/app/services/product_cache.py
+++ b/src/app/services/product_cache.py
@@ -1,0 +1,34 @@
+from __future__ import annotations
+
+import time
+
+from app.domain.models import DataSource, GeneralizedProduct
+
+
+class ProductCache:
+    """
+    Einfacher TTL-basierter In-Memory Cache für Produkte.
+    Verhindert redundante externe API-Aufrufe.
+    """
+
+    def __init__(self, ttl_seconds: int) -> None:
+        self._ttl = ttl_seconds
+        # Key: (DataSource, product_id), Value: (GeneralizedProduct, timestamp)
+        self._storage: dict[tuple[DataSource, str], tuple[GeneralizedProduct, float]] = {}
+
+    def get(self, source: DataSource, product_id: str) -> GeneralizedProduct | None:
+        """Holt ein Produkt aus dem Cache, sofern vorhanden und nicht abgelaufen."""
+        key = (source, product_id)
+        if key not in self._storage:
+            return None
+
+        product, timestamp = self._storage[key]
+        if (time.time() - timestamp) > self._ttl:
+            del self._storage[key]
+            return None
+
+        return product
+
+    def set(self, source: DataSource, product_id: str, product: GeneralizedProduct) -> None:
+        """Speichert ein Produkt im Cache mit aktuellem Zeitstempel."""
+        self._storage[(source, product_id)] = (product, time.time())

--- a/tests/unit/test_log_service.py
+++ b/tests/unit/test_log_service.py
@@ -13,6 +13,7 @@ from app.domain.models import (
 )
 from app.repositories.log_repository import InMemoryLogRepository
 from app.services.log_service import LogService
+from app.services.product_cache import ProductCache
 
 
 def _make_product(is_liquid: bool = False) -> GeneralizedProduct:
@@ -37,8 +38,11 @@ async def test_daily_hydration_only_counts_liquids():
     mock_adapter.fetch_by_id.return_value = _make_product(is_liquid=True)
 
     repo = InMemoryLogRepository()
+    cache = ProductCache(ttl_seconds=60)
     service = LogService(
-        adapter_registry={DataSource.OPEN_FOOD_FACTS: mock_adapter}, repository=repo
+        adapter_registry={DataSource.OPEN_FOOD_FACTS: mock_adapter},
+        repository=repo,
+        product_cache=cache,
     )
 
     payload = LogEntryCreate(
@@ -57,8 +61,11 @@ async def test_tenant_isolation():
     mock_adapter.fetch_by_id.return_value = _make_product()
 
     repo = InMemoryLogRepository()
+    cache = ProductCache(ttl_seconds=60)
     service = LogService(
-        adapter_registry={DataSource.OPEN_FOOD_FACTS: mock_adapter}, repository=repo
+        adapter_registry={DataSource.OPEN_FOOD_FACTS: mock_adapter},
+        repository=repo,
+        product_cache=cache,
     )
 
     payload = LogEntryCreate(

--- a/tests/unit/test_product_cache.py
+++ b/tests/unit/test_product_cache.py
@@ -1,0 +1,92 @@
+import time
+from decimal import Decimal
+from unittest.mock import patch
+
+from app.domain.models import DataSource, GeneralizedProduct, Macronutrients
+from app.services.product_cache import ProductCache
+
+
+def test_cache_hit_and_miss():
+    cache = ProductCache(ttl_seconds=60)
+    product = GeneralizedProduct(
+        id="123",
+        source=DataSource.OPEN_FOOD_FACTS,
+        name="Test Product",
+        macronutrients=Macronutrients(
+            calories_kcal=Decimal("100"),
+            protein_g=Decimal("10"),
+            carbohydrates_g=Decimal("20"),
+            fat_g=Decimal("5"),
+        ),
+    )
+
+    # Miss
+    assert cache.get(DataSource.OPEN_FOOD_FACTS, "123") is None
+
+    # Set
+    cache.set(DataSource.OPEN_FOOD_FACTS, "123", product)
+
+    # Hit
+    cached = cache.get(DataSource.OPEN_FOOD_FACTS, "123")
+    assert cached == product
+
+
+def test_cache_ttl_expiry():
+    ttl = 10
+    cache = ProductCache(ttl_seconds=ttl)
+    product = GeneralizedProduct(
+        id="123",
+        source=DataSource.OPEN_FOOD_FACTS,
+        name="Test Product",
+        macronutrients=Macronutrients(
+            calories_kcal=Decimal("100"),
+            protein_g=Decimal("10"),
+            carbohydrates_g=Decimal("20"),
+            fat_g=Decimal("5"),
+        ),
+    )
+
+    now = time.time()
+    with patch("time.time") as mock_time:
+        mock_time.return_value = now
+        cache.set(DataSource.OPEN_FOOD_FACTS, "123", product)
+
+        # Still valid
+        mock_time.return_value = now + ttl - 1
+        assert cache.get(DataSource.OPEN_FOOD_FACTS, "123") == product
+
+        # Expired
+        mock_time.return_value = now + ttl + 1
+        assert cache.get(DataSource.OPEN_FOOD_FACTS, "123") is None
+
+
+def test_cache_different_sources():
+    cache = ProductCache(ttl_seconds=60)
+    product_off = GeneralizedProduct(
+        id="123",
+        source=DataSource.OPEN_FOOD_FACTS,
+        name="OFF Product",
+        macronutrients=Macronutrients(
+            calories_kcal=Decimal("100"),
+            protein_g=Decimal("10"),
+            carbohydrates_g=Decimal("20"),
+            fat_g=Decimal("5"),
+        ),
+    )
+    product_usda = GeneralizedProduct(
+        id="123",
+        source=DataSource.USDA_FOODDATA,
+        name="USDA Product",
+        macronutrients=Macronutrients(
+            calories_kcal=Decimal("200"),
+            protein_g=Decimal("20"),
+            carbohydrates_g=Decimal("40"),
+            fat_g=Decimal("10"),
+        ),
+    )
+
+    cache.set(DataSource.OPEN_FOOD_FACTS, "123", product_off)
+    cache.set(DataSource.USDA_FOODDATA, "123", product_usda)
+
+    assert cache.get(DataSource.OPEN_FOOD_FACTS, "123") == product_off
+    assert cache.get(DataSource.USDA_FOODDATA, "123") == product_usda


### PR DESCRIPTION
This change introduces a simple, dependency-free TTL-based product cache to the Nutrition & Hydration Tracking API. The cache stores normalized product data from external sources (Open Food Facts and USDA FoodData) to avoid redundant network calls.

Key changes:
1. **Configuration:** Added `cache_ttl_seconds` (default 3600s) to `src/app/core/config.py`.
2. **ProductCache Service:** Created `src/app/services/product_cache.py` which uses a Python dictionary and timestamps to manage cached `GeneralizedProduct` items.
3. **Integration:** Updated `LogService.create_entry` in `src/app/services/log_service.py` to check the cache before calling an adapter's `fetch_by_id` method and to update the cache on success.
4. **Dependency Injection:** Registered `ProductCache` as a singleton in `src/app/api/dependencies.py`.
5. **Testing:** 
   - Added `tests/unit/test_product_cache.py` covering cache hits, misses, and TTL expiration (using time mocking).
   - Updated `tests/unit/test_log_service.py` to correctly initialize `LogService` with the new cache dependency.
6. **Validation:** Ensured all tests pass and that the codebase satisfies `ruff` linting and `mypy --strict` type checking.

---
*PR created automatically by Jules for task [17380795894522386985](https://jules.google.com/task/17380795894522386985) started by @cschaf*